### PR TITLE
Added TuneIn receiver with media control support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This node supported a couple of applications with room to grow. This allows it t
   <li>GogolePlayMovies - media control only</li>
   <li>Netflix - media control only</li>
   <li>Spotify - media control only</li>
+  <li>TuneIn - media control only</li>
   <li>YouTube</li>
 </ul>
 

--- a/castv2-sender.js
+++ b/castv2-sender.js
@@ -16,6 +16,8 @@ module.exports = function(RED) {
     const SpotifyReceiverAdapter = require('./lib/SpotifyReceiverAdapter');
     const YouTubeReceiver = require('./lib/YouTubeReceiver');
     const YouTubeReceiverAdapter = require('./lib/YouTubeReceiverAdapter');
+    const TuneInReceiver = require('./lib/TuneInReceiver');
+    const TuneInReceiverAdapter = require('./lib/TuneInReceiverAdapter');
 
     function CastV2ConnectionNode(config) {
         RED.nodes.createNode(this, config);
@@ -375,7 +377,8 @@ module.exports = function(RED) {
             GooglePlayMusicReceiver,
             GooglePlayMoviesReceiver,
             SpotifyReceiver,
-            YouTubeReceiver
+            YouTubeReceiver,
+            TuneInReceiver
         ];
 
         this.receiver = null;
@@ -473,6 +476,9 @@ module.exports = function(RED) {
                 case YouTubeReceiver.APP_ID:
                     return YouTubeReceiverAdapter;
                     break;
+                case TuneInReceiver.APP_ID:
+                    return TuneInReceiverAdapter;
+                    break;
                 default:
                     return null;
                     break;
@@ -498,6 +504,9 @@ module.exports = function(RED) {
                     break;
                 case "YouTube":
                     return YouTubeReceiver;
+                    break;
+                case "TuneIn":
+                    return TuneInReceiver;
                     break;
                 default:
                     return null;

--- a/lib/TuneInReceiver.js
+++ b/lib/TuneInReceiver.js
@@ -1,0 +1,13 @@
+"use strict";
+const util = require('util');
+const MediaReceiverBase = require('./MediaReceiverBase');
+
+function TuneInReceiver(client, session) {
+    MediaReceiverBase.apply(this, arguments);
+}
+
+TuneInReceiver.APP_ID = '12F05308';
+
+util.inherits(TuneInReceiver, MediaReceiverBase);
+
+module.exports = TuneInReceiver;

--- a/lib/TuneInReceiverAdapter.js
+++ b/lib/TuneInReceiverAdapter.js
@@ -1,0 +1,28 @@
+"use strict";
+const util = require('util');
+const TuneInReceiver = require('./TuneInReceiver');
+
+function TuneInReceiverAdapter() {}
+TuneInReceiverAdapter.castV2App = TuneInReceiver;
+
+/*
+* Extends receiver for async usage
+*/
+TuneInReceiverAdapter.initReceiver = function(node, receiver) {
+    receiver.getStatusAsync = util.promisify(receiver.getStatus);
+    receiver.pauseAsync = util.promisify(receiver.pause);
+    receiver.playAsync = util.promisify(receiver.play);
+    receiver.seekAsync = util.promisify(receiver.seek);
+    receiver.stopAsync = util.promisify(receiver.stop);
+
+    return receiver;
+};
+
+/*
+* App command handler
+*/
+TuneInReceiverAdapter.sendAppCommandAsync = function(receiver, command) {
+    throw new Error("Unknown command");
+};
+
+module.exports = TuneInReceiverAdapter;


### PR DESCRIPTION
Added TuneIn-Receiver/Adapter with support for the media commands GET_STATUS, PLAY, STOP, PAUSE, SEEK (e.g. Podcasts). I do not see the necessity for QUEUE_NEXT and QUEUE_PREV.
By the way, maybe it's better to have only one default media control only receiver for all not directly supported apps, which supports the simple media commands. This should work for most apps, without much programming effort. But this is a design decision.