### PR TITLE
Change default .mp4 content type to video/mp4

### DIFF
--- a/lib/DefaultMediaReceiverAdapter.js
+++ b/lib/DefaultMediaReceiverAdapter.js
@@ -125,7 +125,7 @@ DefaultMediaReceiverAdapter.getContentType = function(fileName) {
         mpa: "audio/mpeg",
         mp2: "audio/x-mpeg",
         mp3: "audio/mp3",
-        mp4: "audio/mp4",
+        mp4: "video/mp4",
         mjpg: "video/x-motion-jpeg",
         mjpeg: "video/x-motion-jpeg",
         mpe: "video/mpeg",


### PR DESCRIPTION
Though there are indeed some audio only mp4 files, I think video/mp4 is a more common MIME type for .mp4 file. An example would be the default mime type mapping for Nginx for .mp4 here: https://github.com/nginx/nginx/blob/master/conf/mime.types#L87